### PR TITLE
Video alt-text

### DIFF
--- a/src/blueskysocial/video.py
+++ b/src/blueskysocial/video.py
@@ -27,12 +27,13 @@ class Video(PostAttachment):
         and returns the blob information from the server response.
     """
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, alt_text: str = ""):
         self._path = path
         self._upload_blob = None
+        self._alt_text = alt_text
 
     def attach_to_post(self, post, session):
-        post.post["embed"] = {"$type": VIDEO_TYPE, "video": self.build(session)}
+        post.post["embed"] = {"$type": VIDEO_TYPE, "video": self.build(session), "alt": self.alt_text}
 
     def build(self, session: dict) -> dict:
         if self._upload_blob is None:
@@ -54,3 +55,13 @@ class Video(PostAttachment):
             resp.raise_for_status()
             self._upload_blob = resp.json()
         return self._upload_blob["blob"]
+
+    @property
+    def alt_text(self):
+        """
+        Returns the alternative text for the image.
+
+        :return: The alternative text for the image.
+        :rtype: str
+        """
+        return self._alt_text

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -13,7 +13,7 @@ class TestVideo(unittest.TestCase):
         video_data = b"example video data"
         mock_post.return_value.json.return_value = {"blob": "uploaded_blob"}
 
-        video = Video(file_path)
+        video = Video(file_path, 'alt-text')
         result = video.build(session)
 
         mock_open.assert_called_once_with(file_path, "rb")
@@ -40,3 +40,7 @@ class TestVideo(unittest.TestCase):
         self.assertTrue("Unsupported video format" in str(context.exception))
         mock_open.assert_called_once_with(file_path, "rb")
         mock_post.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()
+    


### PR DESCRIPTION
Have added support for alt-text to video posts.
Contrary to the image type the alt-text is optional to keep the code backwards-compatible.
